### PR TITLE
29 normalise amounts

### DIFF
--- a/src/incoming.js
+++ b/src/incoming.js
@@ -127,15 +127,17 @@ IncomingServer.allPendingReturned = (success, data) => {
 }
 
 IncomingServer.currentBatchPrepared = (success, data) => {
-  if (!success || !data || !data.currentBatch) {
+  if (!success || !data || !data.currentBatch || !data.currentFlattened || !data.numFlattened) {
     IncomingServer.processing = false
     return
   }
   IncomingServer.runtime.currentBatch = data.currentBatch
+  IncomingServer.runtime.currentFlattened = data.currentFlattened
+  IncomingServer.runtime.numFlattened = data.numFlattened
   RetrieveSubchainAddresses.run({
     subClient: IncomingServer.subClient,
     chosenOutgoing: IncomingServer.runtime.chosenOutgoing,
-    currentBatch: data.currentBatch,
+    numAddresses: data.numFlattened,
   }, IncomingServer.retrievedSubchainAddresses)
 }
 

--- a/src/lib/FlattenTransactions.js
+++ b/src/lib/FlattenTransactions.js
@@ -1,0 +1,74 @@
+const lodash = require('lodash')
+
+let Logger = require('./Logger.js') //eslint-disable-line
+
+const FlattenTransactions = {}
+
+FlattenTransactions.incoming = (options, callback) => {
+  const required = ['amountToFlatten']
+  if (lodash.intersection(Object.keys(options), required).length !== required.length) {
+    Logger.writeLog('FLT_001', 'invalid options', { options, required })
+    callback(false, { message: 'invalid options provided to FlattenTransactions.incoming' })
+    return
+  }
+
+  FlattenTransactions.runtime = {
+    callback,
+    amountToFlatten: options.amountToFlatten,
+  }
+  FlattenTransactions.flattenIncoming()
+}
+
+FlattenTransactions.flattenIncoming = () => {
+  const totalInt = Math.floor(FlattenTransactions.runtime.amountToFlatten)
+  const totalIntString = totalInt.toString()
+  const decimal = FlattenTransactions.runtime.amountToFlatten - totalInt
+  const safeDecimal = FlattenTransactions.satoshiParser(decimal)
+
+  let flattened = []
+
+  for (let i = 0; i < totalIntString.length; i++) {
+    const factor = 1 * Math.pow(10, totalIntString.length - (i + 1))
+    const numFactors = parseInt(totalIntString[i], 10)
+    for (let j = 0; j < numFactors; j++) {
+      if (safeDecimal > 0 && i === totalIntString.length - 1 && j === numFactors - 1) {
+        flattened.push(FlattenTransactions.satoshiParser(parseInt(factor, 10) + safeDecimal))
+      } else {
+        flattened.push(parseInt(factor, 10))
+      }
+    }
+  }
+
+  if (flattened.length === 1) {
+    flattened = []
+    for (let k = 0; k < 10; k++) {
+      if (safeDecimal > 0 && k === 9) {
+        flattened.push(FlattenTransactions.satoshiParser((totalInt / 10) + safeDecimal))
+      } else {
+        flattened.push(totalInt / 10)
+      }
+    }
+  }
+
+  const reduced = flattened.reduce((acc, x) => x + acc, 0)
+  const safeReduced = FlattenTransactions.satoshiParser(reduced)
+
+  if (safeReduced !== FlattenTransactions.runtime.amountToFlatten) {
+    Logger.writeLog('FLT_002', 'unable to correctly flatten amount', { runtime: FlattenTransactions.runtime, flattened })
+    FlattenTransactions.runtime.callback(false, {
+      flattened,
+    })
+    return
+  }
+
+  FlattenTransactions.runtime.callback(true, {
+    flattened,
+  })
+}
+
+FlattenTransactions.satoshiParser = (unsafe) => {
+  const satoshiFactor = 100000000
+  return Math.round(unsafe * satoshiFactor) / satoshiFactor
+}
+
+module.exports = FlattenTransactions

--- a/src/lib/ProcessIncoming.js
+++ b/src/lib/ProcessIncoming.js
@@ -52,12 +52,12 @@ ProcessIncoming.transactionFailed = () => {
 }
 
 ProcessIncoming.checkDecrypted = (success, data) => {
-  if (!success || !data || !data.decrypted || !data.transaction) {
+  if (!success || !data || !data.decrypted || !data.decrypted.n || !data.decrypted.t || !data.transaction) {
     Logger.writeLog('PROI_002', 'failed to decrypt transaction data', { success })
     ProcessIncoming.transactionFailed()
     return
   }
-  ProcessIncoming.runtime.navClient.validateAddress(data.decrypted).then((addressInfo) => {
+  ProcessIncoming.runtime.navClient.validateAddress(data.decrypted.n).then((addressInfo) => {
     if (addressInfo.isvalid !== true) {
       Logger.writeLog('PROI_003', 'encrypted address invalid', { success, data })
       ProcessIncoming.transactionFailed()

--- a/src/lib/RetrieveSubchainAddresses.js
+++ b/src/lib/RetrieveSubchainAddresses.js
@@ -7,7 +7,7 @@ let NavCoin = require('./NavCoin.js') //eslint-disable-line
 const RetrieveSubchainAddresses = {}
 
 RetrieveSubchainAddresses.run = (options, callback) => {
-  const required = ['subClient', 'chosenOutgoing', 'currentBatch']
+  const required = ['subClient', 'chosenOutgoing', 'numAddresses']
   if (lodash.intersection(Object.keys(options), required).length !== required.length) {
     Logger.writeLog('RSC_001', 'invalid options', { options, required })
     callback(false, { message: 'invalid options provided to RetrieveSubchainAddresses.run' })
@@ -17,7 +17,7 @@ RetrieveSubchainAddresses.run = (options, callback) => {
     callback,
     subClient: options.subClient,
     chosenOutgoing: options.chosenOutgoing,
-    currentBatch: options.currentBatch,
+    numAddresses: options.numAddresses,
   }
 
   RetrieveSubchainAddresses.getSubAddresses()
@@ -37,7 +37,7 @@ RetrieveSubchainAddresses.getSubAddresses = () => {
     form: {
       type: 'SUBCHAIN',
       account: 'OUTGOING',
-      num_addresses: RetrieveSubchainAddresses.runtime.currentBatch.length,
+      num_addresses: RetrieveSubchainAddresses.runtime.numAddresses,
     },
   }
 
@@ -85,10 +85,10 @@ RetrieveSubchainAddresses.checkSubAddresses = (outgoingSubAddresses) => {
     RetrieveSubchainAddresses.runtime.callback(false, { message: 'outgoing server must provide at least one sub address' })
     return
   }
-  if (outgoingSubAddresses.length < RetrieveSubchainAddresses.runtime.currentBatch.length) {
+  if (outgoingSubAddresses.length < RetrieveSubchainAddresses.runtime.numAddresses) {
     Logger.writeLog('RSC_008', 'outgoing server did not provide enough sub addresses', {
       subAddressesLength: outgoingSubAddresses.length,
-      currentBatchLength: RetrieveSubchainAddresses.runtime.currentBatch.length,
+      numAddresses: RetrieveSubchainAddresses.runtime.numAddresses,
     })
     RetrieveSubchainAddresses.runtime.callback(false, { message: 'outgoing server did not provide enough sub addresses' })
     return

--- a/src/settings/private.settings.json
+++ b/src/settings/private.settings.json
@@ -20,7 +20,7 @@
   "maxHolding": 100,
   "minNavTransactions": 3,
   "maxNavTransactions": 8,
-  "txFee": 0.001,
+  "txFee": 0.0001,
   "maxEncryptionAttempts": 10,
   "encryptionStrength": {
     "INCOMING": 2048,
@@ -30,8 +30,8 @@
     "INCOMING": 344,
     "OUTGOING": 172
   },
-  "subCoinsPerTx": 10,
-  "subChainTxFee": 0.001,
+  "subCoinsPerTx": 1,
+  "subChainTxFee": 0.0001,
   "minConfs": 1,
   "blockThreshold": {
     "checking": 5,

--- a/test/FlattenTransactions.spec.js
+++ b/test/FlattenTransactions.spec.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const expect = require('expect')
+const rewire = require('rewire')
+const sinon = require('sinon')
+
+const FlattenTransactions = rewire('../src/lib/FlattenTransactions')
+
+describe('[FlattenTransactions]', () => {
+  describe('(incoming)', () => {
+    it('should fail on params', (done) => {
+      const callback = (success) => {
+        expect(success).toBe(false)
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'FLT_001')
+        done()
+      }
+      const mockLogger = {
+        writeLog: sinon.spy(),
+      }
+      FlattenTransactions.__set__('Logger', mockLogger)
+      FlattenTransactions.incoming({
+        memes: 'HARAMBE',
+      }, callback)
+    })
+    it('should flatten transactions 1126.65', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(10)
+        expect(data.flattened[0]).toBe(1000)
+        expect(data.flattened[1]).toBe(100)
+        expect(data.flattened[2]).toBe(10)
+        expect(data.flattened[3]).toBe(10)
+        expect(data.flattened[4]).toBe(1)
+        expect(data.flattened[5]).toBe(1)
+        expect(data.flattened[6]).toBe(1)
+        expect(data.flattened[7]).toBe(1)
+        expect(data.flattened[8]).toBe(1)
+        expect(data.flattened[9]).toBe(1.65)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(1126.65)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 1126.65,
+      }, callback)
+    })
+    it('should flatten transactions 10', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(10)
+        expect(data.flattened[0]).toBe(1)
+        expect(data.flattened[9]).toBe(1)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(10)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 10,
+      }, callback)
+    })
+    it('should flatten transactions 10000', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(10)
+        expect(data.flattened[0]).toBe(1000)
+        expect(data.flattened[9]).toBe(1000)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(10000)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 10000,
+      }, callback)
+    })
+    it('should flatten transactions 100.99999999', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(10)
+        expect(data.flattened[0]).toBe(10)
+        expect(data.flattened[9]).toBe(10.99999999)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(100.99999999)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 100.99999999,
+      }, callback)
+    })
+    it('should flatten transactions 9999.99999999', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(36)
+        expect(data.flattened[0]).toBe(1000)
+        expect(data.flattened[9]).toBe(100)
+        expect(data.flattened[18]).toBe(10)
+        expect(data.flattened[27]).toBe(1)
+        expect(data.flattened[35]).toBe(1.99999999)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(9999.99999999)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 9999.99999999,
+      }, callback)
+    })
+    it('should flatten transactions 333.33333333', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.flattened.length).toBe(9)
+        expect(data.flattened[0]).toBe(100)
+        expect(data.flattened[3]).toBe(10)
+        expect(data.flattened[6]).toBe(1)
+        expect(data.flattened[8]).toBe(1.33333333)
+        const reduced = data.flattened.reduce((acc, x) => x + acc)
+        const safeReduced = Math.round(reduced * 100000000) / 100000000
+        expect(safeReduced).toBe(333.33333333)
+        done()
+      }
+      FlattenTransactions.incoming({
+        totalToSend: 333.33333333,
+      }, callback)
+    })
+    it('should fail to flatten', (done) => {
+      const callback = (success) => {
+        expect(success).toBe(false)
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'FLT_002')
+        done()
+      }
+      const mockLogger = {
+        writeLog: sinon.spy(),
+      }
+      FlattenTransactions.__set__('Logger', mockLogger)
+      FlattenTransactions.incoming({
+        totalToSend: 'XYZ',
+      }, callback)
+    })
+  })
+})

--- a/test/FlattenTransactions.spec.js
+++ b/test/FlattenTransactions.spec.js
@@ -43,7 +43,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 1126.65,
+        amountToFlatten: 1126.65,
       }, callback)
     })
     it('should flatten transactions 10', (done) => {
@@ -58,7 +58,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 10,
+        amountToFlatten: 10,
       }, callback)
     })
     it('should flatten transactions 10000', (done) => {
@@ -73,7 +73,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 10000,
+        amountToFlatten: 10000,
       }, callback)
     })
     it('should flatten transactions 100.99999999', (done) => {
@@ -88,7 +88,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 100.99999999,
+        amountToFlatten: 100.99999999,
       }, callback)
     })
     it('should flatten transactions 9999.99999999', (done) => {
@@ -106,7 +106,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 9999.99999999,
+        amountToFlatten: 9999.99999999,
       }, callback)
     })
     it('should flatten transactions 333.33333333', (done) => {
@@ -123,7 +123,7 @@ describe('[FlattenTransactions]', () => {
         done()
       }
       FlattenTransactions.incoming({
-        totalToSend: 333.33333333,
+        amountToFlatten: 333.33333333,
       }, callback)
     })
     it('should fail to flatten', (done) => {
@@ -138,7 +138,7 @@ describe('[FlattenTransactions]', () => {
       }
       FlattenTransactions.__set__('Logger', mockLogger)
       FlattenTransactions.incoming({
-        totalToSend: 'XYZ',
+        amountToFlatten: 'XYZ',
       }, callback)
     })
   })

--- a/test/ProcessIncoming.spec.js
+++ b/test/ProcessIncoming.spec.js
@@ -3,340 +3,472 @@
 const expect = require('expect')
 const rewire = require('rewire')
 const sinon = require('sinon')
-const config = require('config')
-
-const globalSettings = config.get('GLOBAL')
-const privateSettings = require('../src/settings/private.settings.json')
 
 let ProcessIncoming = rewire('../src/lib/ProcessIncoming')
 
 let mockLogger = {
-    writeLog: sinon.spy(),
+  writeLog: sinon.spy(),
 }
 
 let mockRuntime = {
-    currentBatch: [],
-    settings: {setting: true},
-    subClient: {test: true},
-    navClient: {test: true},
-    outgoingPubKey: '123443',
-    subAddresses: [],
-    transactionsToReturn: [],
-    successfulSubTransactions: [],
-    remainingTransactions: [],
+  currentBatch: [],
+  settings: { setting: true },
+  subClient: { test: true },
+  navClient: { test: true },
+  outgoingPubKey: '123443',
+  subAddresses: [],
+  transactionsToReturn: [],
+  successfulSubTransactions: [],
+  remainingTransactions: [],
 }
 
 beforeEach(() => {
-    ProcessIncoming = rewire('../src/lib/ProcessIncoming')
-    mockLogger = {
-        writeLog: sinon.spy()
-    }
-    mockRuntime = {}
+  ProcessIncoming = rewire('../src/lib/ProcessIncoming')
+  mockLogger = {
+    writeLog: sinon.spy(),
+  }
+  mockRuntime = {}
 })
 
 describe('[ProcessIncoming]', () => {
-    describe('(run)', () => {
-        it('should fail on params', (done) => {
-            const callback = (success, data) => {
-                expect(success).toBe(false)
-                expect(data.message).toBeA('string')
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
+  describe('(run)', () => {
+    it('should fail on params', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(false)
+        expect(data.message).toBeA('string')
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        done()
+      }
 
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.run({junkParam: 1234}, callback)
-        })
-        it('should callback with success when remainingTransactions < 1', (done) => {
-            const callback = (success, data) => {
-                expect(success).toBe(true)
-                expect(data.successfulSubTransactions.length).toBe(0)
-                expect(data.transactionsToReturn.length).toBe(0)
-                done()
-            }
-            const mockOptions = {
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {test: true},
-                outgoingPubKey: '123443',
-                subAddresses: [],
-            }
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.run(mockOptions, callback)
-        })
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.run({ junkParam: 1234 }, callback)
     })
-    describe('(transActionFailed)', () => {
-        it('should transfer policy from remainingTransactions to TransactionsToReturn when failed', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {test: true},
-                outgoingPubKey: '123443',
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.transactionFailed()
-            expect(ProcessIncoming.runtime.remainingTransactions.length).toBe(0)
-            expect(ProcessIncoming.runtime.transactionsToReturn.length).toBe(1)
-            done()
-        })
+    it('should set the variables into runtime and call processPending', (done) => {
+      ProcessIncoming.processPending = () => {
+        expect(ProcessIncoming.runtime.callback).toBe(callback)
+        expect(ProcessIncoming.runtime.currentBatch).toBe(mockOptions.currentBatch)
+        expect(ProcessIncoming.runtime.settings).toBe(mockOptions.settings)
+        expect(ProcessIncoming.runtime.subClient).toBe(mockOptions.subClient)
+        expect(ProcessIncoming.runtime.navClient).toBe(mockOptions.navClient)
+        expect(ProcessIncoming.runtime.outgoingPubKey).toBe(mockOptions.outgoingPubKey)
+        expect(ProcessIncoming.runtime.subAddresses).toBe(mockOptions.subAddresses)
+        done()
+      }
+      const callback = () => {}
+      const mockOptions = {
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: { test: true },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.run(mockOptions, callback)
     })
-    describe('(checkDecrypted)', () => {
-        it('should log a message out when success is false', (done) => {
-            const mockTransactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.transactionFailed = mockTransactionFailed
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.checkDecrypted(false, {transaction:true,data:true})
-        })
-        it('should log a message out when isValid is false', (done) => {
-            const callback = (success, data) => {
-            }
-            const addressInfo = {isvalid:false}
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.resolve(addressInfo)
-                    },
-                    test: true
-                },
-                outgoingPubKey: '123443',
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.transactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.checkDecrypted(true, {transaction:true,decrypted:true})
-        })
-        it('should log a message out when validateAddress call comes back false', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: '123443',
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.transactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.checkDecrypted(true, {transaction:true,decrypted:true})
-        })
+  })
+  describe('(processPending)', () => {
+    it('should callback with success when remainingTransactions < 1', (done) => {
+      const callback = (success, data) => {
+        expect(success).toBe(true)
+        expect(data.successfulSubTransactions.length).toBe(0)
+        expect(data.transactionsToReturn.length).toBe(0)
+        done()
+      }
+      mockRuntime = {
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: { test: true },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        remainingTransactions: [],
+        successfulSubTransactions: [],
+        transactionsToReturn: [],
+        callback,
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.processPending()
+    })
+    it('should call getEncrypted', (done) => {
+      mockRuntime = {
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: { test: true },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        remainingTransactions: ['ABC'],
+        successfulSubTransactions: [],
+        transactionsToReturn: [],
+      }
 
-    })
-    describe('(reEncryptAddress)', ()=> {
-        it('should log a message when the encryption fails', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: {
-                    encrypt: () => {return '12345'}
-                },
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.reEncryptAddress(true, {transaction:true,decrypted:true}, 0)
-            sinon.assert.calledOnce(mockLogger.writeLog)
-            done()
-        })
-        it('should log a message when the counter exceeds the limit', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: {
-                    encrypt: () => {return '00000000'}
-                },
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.reEncryptAddress(true, {transaction:true,decrypted:true}, 11)
-            sinon.assert.calledOnce(mockLogger.writeLog)
-            done()
-        })
-        it('should log a message when the counter exceeds the limit', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: {
-                    encrypt: () => {return '00000000'}
-                },
-                subAddresses: [],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: [],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.reEncryptAddress(true, {transaction:true,decrypted:true}, 11)
-            sinon.assert.calledOnce(mockLogger.writeLog)
-            done()
-        })
-    })
-    describe('(sentSubToOutgoing)', ()=> {
-        it('should log a message out when success is false', (done) => {
-            const mockTransactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.transactionFailed = mockTransactionFailed
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.sentSubToOutgoing(false, {transaction:true,data:true})
-        })
-        it('should log a message out when no data is false', (done) => {
-            const mockTransactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.transactionFailed = mockTransactionFailed
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.sentSubToOutgoing(true, {sendOutcome:false,data:true})
-        })
-        it('should remove data from subAddresses and remainingTransactions and add to successfulSubTransactions', (done) => {
-            const mockTransactionFailed = () => {
-                sinon.assert.calledOnce(mockLogger.writeLog)
-                done()
-            }
-            ProcessIncoming.transactionFailed = mockTransactionFailed
-            ProcessIncoming.__set__('Logger', mockLogger)
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: {
-                    encrypt: () => {return '00000000'}
-                },
-                subAddresses: ['1234'],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: ['1234'],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            ProcessIncoming.sentSubToOutgoing(true, {sendOutcome:true,transaction:'1234'})
-            expect(mockRuntime.subAddresses.length).toBe(0)
-            expect(mockRuntime.remainingTransactions.length).toBe(0)
-            expect(mockRuntime.successfulSubTransactions.length).toBe(1)
-            done()
+      const mockEncryptedData = {
+        getEncrypted: (options, callback) => {
+          expect(options.transaction).toBe('ABC')
+          expect(options.client).toBe(mockRuntime.navClient)
+          expect(callback).toBe(ProcessIncoming.checkDecrypted)
+          done()
+        },
+      }
 
-        })
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.__set__('EncryptedData', mockEncryptedData)
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.processPending()
     })
-    describe('makeSubchainTx', (done)=> {
-        it('should call sendToAddress', (done) => {
-            const callback = (success, data) => {
-            }
-            mockRuntime = {
-                callback,
-                currentBatch: [],
-                settings: {setting: true},
-                subClient: {test: true},
-                navClient: {
-                    validateAddress: () => {
-                        return Promise.reject({message:'mock failure'})
-                    },
-                    test: true
-                },
-                outgoingPubKey: {
-                    encrypt: () => {return '00000000'}
-                },
-                subAddresses: ['1234'],
-                transactionsToReturn: [],
-                successfulSubTransactions: [],
-                remainingTransactions: ['1234'],
-            }
-            ProcessIncoming.runtime = mockRuntime
-            const mockSendToAddress = {
-                send: sinon.spy()
-            }
-            ProcessIncoming.__set__('SendToAddress',mockSendToAddress)
-            ProcessIncoming.__set__('Logger', mockLogger)
-            ProcessIncoming.makeSubchainTx('test','test')
-            sinon.assert.calledOnce(mockSendToAddress.send)
-            done()
-        })
+  })
+  describe('(transactionFailed)', () => {
+    it('should transfer policy from remainingTransactions to TransactionsToReturn when failed', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: { test: true },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.transactionFailed()
+      expect(ProcessIncoming.runtime.remainingTransactions.length).toBe(0)
+      expect(ProcessIncoming.runtime.transactionsToReturn.length).toBe(1)
+      done()
     })
+  })
+  describe('(checkDecrypted)', () => {
+    it('should log a message out when success is false', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'PROI_002')
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(false, { transaction: true, data: true })
+    })
+    it('should log a message out when n or t is not found in data', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'PROI_002')
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(true, { transaction: true, decrypted: { x: true, y: false } })
+    })
+    it('should log a message out when the transaction is not parsed', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'PROI_002')
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(true, { decrypted: { n: 'XYZ', t: 120 } })
+    })
+    it('should log a message out when isValid is false', (done) => {
+      const callback = () => {}
+      const addressInfo = { isvalid: false }
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.resolve(addressInfo)
+          },
+          test: true,
+        },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.transactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'PROI_003')
+        done()
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(true, { transaction: true, decrypted: { n: 'XYZ', t: 120 } })
+    })
+    it('should log a message out when validateAddress call comes back false', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.transactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        sinon.assert.calledWith(mockLogger.writeLog, 'PROI_004')
+        done()
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(true, { transaction: true, decrypted: { n: 'XYZ', t: 120 } })
+    })
+    it('should call reEncryptAddress if everything has worked', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.resolve({ isvalid: true })
+          },
+          test: true,
+        },
+        outgoingPubKey: '123443',
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.reEncryptAddress = (decrypted, transaction, counter) => {
+        sinon.assert.notCalled(mockLogger.writeLog)
+        expect(decrypted).toEqual({ n: 'XYZ', t: 120 })
+        expect(transaction).toBe('ABC')
+        expect(counter).toBe(0)
+        done()
+      }
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.checkDecrypted(true, { transaction: 'ABC', decrypted: { n: 'XYZ', t: 120 } })
+    })
+  })
+  describe('(reEncryptAddress)', () => {
+    it('should log a message when the encryption fails', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => { return '12345' },
+        },
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.reEncryptAddress({ n: 'XYZ', t: 120 }, 'ABC', 0)
+      sinon.assert.calledOnce(mockLogger.writeLog)
+      sinon.assert.calledWith(mockLogger.writeLog, 'PROI_005')
+      done()
+    })
+    it('should log a message when the counter exceeds the limit', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => { return '00000000' },
+        },
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.reEncryptAddress({ n: 'XYZ', t: 120 }, 'ABC', 11)
+      sinon.assert.calledOnce(mockLogger.writeLog)
+      sinon.assert.calledWith(mockLogger.writeLog, 'PROI_006')
+      done()
+    })
+    it('should call makeSubchainTx when everything okay', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => {
+            return '12345678901234567890123456789012345678901234567890123456789012345678901234567890123456'
+                 + '789012345678901234567890123456789012345678901234567890123456789012345678901234567890==' },
+        },
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
 
+      ProcessIncoming.makeSubchainTx = (encrypted, transaction) => {
+        expect(encrypted).toBe(mockRuntime.outgoingPubKey.encrypt())
+        expect(transaction).toBe('ABC')
+        done()
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.reEncryptAddress({ n: 'XYZ', t: 120 }, 'ABC', 0)
+    })
+    it('should catch errors thrown by the encryption', (done) => {
+      const callback = () => {}
+      const Exception = () => 'manual error'
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => {
+            throw new Exception()
+          },
+        },
+        subAddresses: [],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: [],
+      }
 
-
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.reEncryptAddress({ n: 'XYZ', t: 120 }, 'ABC', 0)
+      sinon.assert.calledOnce(mockLogger.writeLog)
+      sinon.assert.calledWith(mockLogger.writeLog, 'PROI_007')
+      done()
+    })
+  })
+  describe('(sentSubToOutgoing)', () => {
+    it('should log a message out when success is false', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.sentSubToOutgoing(false, { transaction: true, data: true })
+    })
+    it('should log a message out when no data is false', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.sentSubToOutgoing(true, { sendOutcome: false, data: true })
+    })
+    it('should remove data from subAddresses and remainingTransactions and add to successfulSubTransactions', (done) => {
+      const mockTransactionFailed = () => {
+        sinon.assert.calledOnce(mockLogger.writeLog)
+        done()
+      }
+      ProcessIncoming.transactionFailed = mockTransactionFailed
+      ProcessIncoming.__set__('Logger', mockLogger)
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => { return '00000000' },
+        },
+        subAddresses: ['1234'],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: ['1234'],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      ProcessIncoming.sentSubToOutgoing(true, { sendOutcome: true, transaction: '1234' })
+      expect(mockRuntime.subAddresses.length).toBe(0)
+      expect(mockRuntime.remainingTransactions.length).toBe(0)
+      expect(mockRuntime.successfulSubTransactions.length).toBe(1)
+      done()
+    })
+  })
+  describe('makeSubchainTx', () => {
+    it('should call sendToAddress', (done) => {
+      const callback = () => {}
+      mockRuntime = {
+        callback,
+        currentBatch: [],
+        settings: { setting: true },
+        subClient: { test: true },
+        navClient: {
+          validateAddress: () => {
+            return Promise.reject({ message: 'mock failure' })
+          },
+          test: true,
+        },
+        outgoingPubKey: {
+          encrypt: () => { return '00000000' },
+        },
+        subAddresses: ['1234'],
+        transactionsToReturn: [],
+        successfulSubTransactions: [],
+        remainingTransactions: ['1234'],
+      }
+      ProcessIncoming.runtime = mockRuntime
+      const mockSendToAddress = {
+        send: sinon.spy(),
+      }
+      ProcessIncoming.__set__('SendToAddress', mockSendToAddress)
+      ProcessIncoming.__set__('Logger', mockLogger)
+      ProcessIncoming.makeSubchainTx('test', 'test')
+      sinon.assert.calledOnce(mockSendToAddress.send)
+      done()
+    })
+  })
 })
-

--- a/test/RetrieveSubchainAddresses.spec.js
+++ b/test/RetrieveSubchainAddresses.spec.js
@@ -26,12 +26,12 @@ describe('[RetrieveSubchainAddresses]', () => {
       const callback = () => {}
       const subClient = { getinfo: () => {} }
       const chosenOutgoing = { ipAddress: '123.123.123.123' }
-      const currentBatch = [1, 2, 3]
+      const numAddresses = 10
       RetrieveSubchainAddresses.getSubAddresses = () => {
         expect(RetrieveSubchainAddresses.runtime.callback).toBe(callback)
         expect(RetrieveSubchainAddresses.runtime.subClient).toBe(subClient)
         expect(RetrieveSubchainAddresses.runtime.chosenOutgoing).toBe(chosenOutgoing)
-        expect(RetrieveSubchainAddresses.runtime.currentBatch).toBe(currentBatch)
+        expect(RetrieveSubchainAddresses.runtime.numAddresses).toBe(numAddresses)
         sinon.assert.notCalled(mockLogger.writeLog)
         done()
       }
@@ -39,7 +39,7 @@ describe('[RetrieveSubchainAddresses]', () => {
         writeLog: sinon.spy(),
       }
       RetrieveSubchainAddresses.__set__('Logger', mockLogger)
-      RetrieveSubchainAddresses.run({ subClient, chosenOutgoing, currentBatch }, callback)
+      RetrieveSubchainAddresses.run({ subClient, chosenOutgoing, numAddresses }, callback)
     })
   })
   describe('(getSubAddresses)', () => {
@@ -48,10 +48,10 @@ describe('[RetrieveSubchainAddresses]', () => {
     })
     it('should build the request and send it to the outgoing server', (done) => {
       const chosenOutgoing = { ipAddress: '123.123.123.123', port: '3000' }
-      const currentBatch = [1, 2, 3]
+      const numAddresses = 10
       RetrieveSubchainAddresses.runtime = {
         chosenOutgoing,
-        currentBatch,
+        numAddresses,
       }
       const mockLogger = {
         writeLog: sinon.spy(),
@@ -60,7 +60,7 @@ describe('[RetrieveSubchainAddresses]', () => {
         expect(RetrieveSubchainAddresses.runtime.outgoingAddress).toBe(chosenOutgoing.ipAddress + ':' + chosenOutgoing.port)
         expect(options.form.type).toBe('SUBCHAIN')
         expect(options.form.account).toBe('OUTGOING')
-        expect(options.form.num_addresses).toBe(3)
+        expect(options.form.num_addresses).toBe(10)
         expect(callback).toBe(RetrieveSubchainAddresses.requestResponse)
         sinon.assert.notCalled(mockLogger.writeLog)
         done()
@@ -72,10 +72,10 @@ describe('[RetrieveSubchainAddresses]', () => {
   })
   it('should build the request and send it to the outgoing server without port', (done) => {
     const chosenOutgoing = { ipAddress: '123.123.123.123' }
-    const currentBatch = [1, 2, 3]
+    const numAddresses = 50
     RetrieveSubchainAddresses.runtime = {
       chosenOutgoing,
-      currentBatch,
+      numAddresses,
     }
     const mockLogger = {
       writeLog: sinon.spy(),
@@ -84,7 +84,7 @@ describe('[RetrieveSubchainAddresses]', () => {
       expect(RetrieveSubchainAddresses.runtime.outgoingAddress).toBe(chosenOutgoing.ipAddress)
       expect(options.form.type).toBe('SUBCHAIN')
       expect(options.form.account).toBe('OUTGOING')
-      expect(options.form.num_addresses).toBe(3)
+      expect(options.form.num_addresses).toBe(50)
       expect(callback).toBe(RetrieveSubchainAddresses.requestResponse)
       sinon.assert.notCalled(mockLogger.writeLog)
       done()
@@ -99,10 +99,10 @@ describe('[RetrieveSubchainAddresses]', () => {
     })
     it('should get an error from the outgoing server', (done) => {
       const chosenOutgoing = { ipAddress: '123.123.123.123', port: '3000' }
-      const currentBatch = [1, 2, 3]
+      const numAddresses = 55
       RetrieveSubchainAddresses.runtime = {
         chosenOutgoing,
-        currentBatch,
+        numAddresses,
         callback: (success, data) => {
           expect(success).toBe(false)
           expect(data.message).toBeA('string')
@@ -119,10 +119,10 @@ describe('[RetrieveSubchainAddresses]', () => {
     })
     it('should get no error and continue', (done) => {
       const chosenOutgoing = { ipAddress: '123.123.123.123', port: '3000' }
-      const currentBatch = [1, 2, 3]
+      const numAddresses = 5
       RetrieveSubchainAddresses.runtime = {
         outgoingAddress: chosenOutgoing.ipAddress + ':' + chosenOutgoing.port,
-        currentBatch,
+        numAddresses,
         callback: () => {},
       }
       RetrieveSubchainAddresses.checkOutgoingCanTransact = (body, outgoingAddress) => {
@@ -263,7 +263,7 @@ describe('[RetrieveSubchainAddresses]', () => {
     })
     it('should fail because less addressses than needed were received from server', (done) => {
       RetrieveSubchainAddresses.runtime = {
-        currentBatch: [1, 2, 3],
+        numAddresses: 10,
         callback: (success, data) => {
           expect(success).toBe(false)
           expect(data.message).toBeA('string')
@@ -280,7 +280,7 @@ describe('[RetrieveSubchainAddresses]', () => {
     })
     it('should receive the correct number of addresses and continue to the validator', (done) => {
       RetrieveSubchainAddresses.runtime = {
-        currentBatch: [1, 2, 3],
+        numAddresses: 3,
       }
       const NavCoin = {
         validateAddresses: (options, callback) => {


### PR DESCRIPTION
Added a lib file to split the transaction into factorial amounts (1,10,100,1000) and add any remaining decimal to the last transaction.

This will mean we have lots of transactions for the same value flying around making it impossible to correctly track each transaction.

This ticket only deals with figuring out how many transactions to make and then requesting the correct amount of addresses from the outgoing server.

My one reservation about this approach is the fact that if someone sends 9999 NAV they will require 36 addresses & create 36 transactions. The fee is only 0.0001 NAV per tx, so it should only cost less than 0.005 NAV to make this transaction which i dont think is a deal breaker.